### PR TITLE
REFACTOR: Move to nextcord and remove dad references from dadbot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,12 +1,12 @@
 import os
 import platform
 import sys
-import discord
+import nextcord
 import yaml
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
-from discord.ext import commands
-from discord.ext.commands import Bot
+from nextcord.ext import commands
+from nextcord.ext.commands import Bot
 
 from noncommands import auto_code_block,quotes
 
@@ -15,7 +15,7 @@ if "CompsciBot" not in str(os.getcwd()):
 with open("config.yaml") as file:
     config = yaml.load(file, Loader=yaml.FullLoader)
 
-intents = discord.Intents.default()
+intents = nextcord.Intents.default()
 
 bot = Bot(command_prefix=config["bot_prefix"], intents=intents)
 
@@ -27,12 +27,12 @@ autoCodeBlock = auto_code_block.AutoCodeBlock(bot)
 @bot.event
 async def on_ready():
     print(f"Logged in as {bot.user.name}")
-    print(f"Discord.py API version: {discord.__version__}")
+    print(f"nextcord.py API version: {nextcord.__version__}")
     print(f"Python version: {platform.python_version()}")
     print(f"Running on: {platform.system()} {platform.release()} ({os.name})")
     print("-------------------")
 
-# Removes the default help command of discord.py to be able to create our custom help command.
+# Removes the default help command of nextcord.py to be able to create our custom help command.
 bot.remove_command("help")
 
 if __name__ == "__main__":
@@ -77,14 +77,14 @@ async def on_command_error(context, error):
         minutes, seconds = divmod(error.retry_after, 60)
         hours, minutes = divmod(minutes, 60)
         hours = hours % 24
-        embed = discord.Embed(
+        embed = nextcord.Embed(
             title="Hey, please slow down!",
             description=f"You can use this command again in {f'{round(hours)} hours' if round(hours) > 0 else ''} {f'{round(minutes)} minutes' if round(minutes) > 0 else ''} {f'{round(seconds)} seconds' if round(seconds) > 0 else ''}.",
             color=config["error"]
         )
         await context.send(embed=embed)
     elif isinstance(error, commands.MissingPermissions):
-        embed = discord.Embed(
+        embed = nextcord.Embed(
             title="Error!",
             description="You are missing the permission `" + ", ".join(
                 error.missing_perms) + "` to execute this command!",

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -6,9 +6,9 @@ import sys
 import aiohttp
 import aiofiles
 import hashlib
-import discord
+import nextcord
 import yaml
-from discord.ext import commands
+from nextcord.ext import commands
 import requests
 import uuid
 import inspirobot
@@ -26,17 +26,16 @@ class Fun(commands.Cog, name="fun"):
     @commands.command(name="randomfact")
     async def randomfact(self, context):
         """
-        [No arguments] Dad has learned a few things, he'll share.
+        [No arguments] A random fact!
         """
-        # This will prevent your bot from stopping everything when doing a web request - see: https://discordpy.readthedocs.io/en/stable/faq.html#how-do-i-make-a-web-request
         async with aiohttp.ClientSession() as session:
             async with session.get("https://uselessfacts.jsph.pl/random.json?language=en") as request:
                 if request.status == 200:
                     data = await request.json()
-                    embed = discord.Embed(description=data["text"], color=config["main_color"])
+                    embed = nextcord.Embed(description=data["text"], color=config["main_color"])
                     await context.send(embed=embed)
                 else:
-                    embed = discord.Embed(
+                    embed = nextcord.Embed(
                         title="Error!",
                         description="There is something wrong with the API, please try again later",
                         color=config["error"]
@@ -46,7 +45,7 @@ class Fun(commands.Cog, name="fun"):
     @commands.command(name="dadjoke")
     async def dadjoke(self, context, searchTerm="", *args):
         """
-        [No arguments] Have Dad tell you one of his classics.
+        [No arguments] Get one of the classics
         """
         url = "https://icanhazdadjoke.com/search?term=" + searchTerm
         headers = {'Accept': 'application/json'}
@@ -80,7 +79,7 @@ class Fun(commands.Cog, name="fun"):
     @commands.command(name="advice")
     async def advice(self, context):
         """
-        [No arguments] Get some fatherly advice.
+        [No arguments] Get some advice.
         """
         r = requests.get("https://api.adviceslip.com/advice")
         await context.reply(r.json()['slip']['advice'])
@@ -103,7 +102,7 @@ class Fun(commands.Cog, name="fun"):
     @commands.command(name="rps")
     async def rock_paper_scissors(self, context):
         """
-        [No arguments] Play a round of Rock-Paper-Scissors with Dad.
+        [No arguments] Play a round of Rock-Paper-Scissors.
         """
         choices = {
             0: "rock",
@@ -115,8 +114,8 @@ class Fun(commands.Cog, name="fun"):
             "🧻": 1,
             "✂": 2
         }
-        embed = discord.Embed(title="Please choose", color=config["warning"])
-        embed.set_author(name=context.author.display_name, icon_url=context.author.avatar_url)
+        embed = nextcord.Embed(title="Please choose", color=config["warning"])
+        embed.set_author(name=context.author.display_name, icon_url=context.author.avatar.url)
         choose_message = await context.send(embed=embed)
         for emoji in reactions:
             await choose_message.add_reaction(emoji)
@@ -133,8 +132,8 @@ class Fun(commands.Cog, name="fun"):
             bot_choice_emote = random.choice(list(reactions.keys()))
             bot_choice_index = reactions[bot_choice_emote]
 
-            result_embed = discord.Embed(color=config["success"])
-            result_embed.set_author(name=context.author.display_name, icon_url=context.author.avatar_url)
+            result_embed = nextcord.Embed(color=config["success"])
+            result_embed.set_author(name=context.author.display_name, icon_url=context.author.avatar.url)
             await choose_message.clear_reactions()
 
             if user_choice_index == bot_choice_index:
@@ -156,8 +155,8 @@ class Fun(commands.Cog, name="fun"):
             await choose_message.edit(embed=result_embed)
         except asyncio.exceptions.TimeoutError:
             await choose_message.clear_reactions()
-            timeout_embed = discord.Embed(title="Too late", color=config["error"])
-            timeout_embed.set_author(name=context.author.display_name, icon_url=context.author.avatar_url)
+            timeout_embed = nextcord.Embed(title="Too late", color=config["error"])
+            timeout_embed.set_author(name=context.author.display_name, icon_url=context.author.avatar.url)
             await choose_message.edit(embed=timeout_embed)
 
     @commands.command(name="uwu")
@@ -179,7 +178,7 @@ class Fun(commands.Cog, name="fun"):
                    'Signs point to yes.', 'Reply hazy, try again.', 'Ask again later.', 'Better not tell you now.',
                    'Cannot predict now.', 'Concentrate and ask again later.', 'Don\'t count on it.', 'My reply is no.',
                    'My sources say no.', 'Outlook not so good.', 'Very doubtful.']
-        embed = discord.Embed(
+        embed = nextcord.Embed(
             title="**My Answer:**",
             description=f"{answers[random.randint(0, len(answers) - 1)]}",
             color=config["success"]
@@ -196,7 +195,7 @@ class Fun(commands.Cog, name="fun"):
         """
         fileName = str(uuid.uuid1()) + str(random.choice(range(1, 1337))) + ".png"
         await self.save_online_cat(fileName)
-        file = discord.File(fileName, filename="newcat.png")
+        file = nextcord.File(fileName, filename="newcat.png")
         await context.send("", file=file)
         os.remove(fileName)
 

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -2,10 +2,10 @@ import os
 import platform
 import sys
 import json
-import discord
+import nextcord
 import yaml
 import random
-from discord.ext import commands
+from nextcord.ext import commands
 from noncommands import summarizer, quotes
 
 if "CompsciBot" not in str(os.getcwd()):
@@ -22,7 +22,7 @@ class general(commands.Cog, name="general"):
         """
         [No arguments] Get some useful (or not) information about the bot.
         """
-        embed = discord.Embed(
+        embed = nextcord.Embed(
             description="CompsciBot",
             color=config["success"]
         )
@@ -66,7 +66,7 @@ class general(commands.Cog, name="general"):
         time = time.split(" ")
         time = time[0]
 
-        embed = discord.Embed(
+        embed = nextcord.Embed(
             title="**Server Name:**",
             description=f"{server}",
             color=config["success"]
@@ -100,7 +100,7 @@ class general(commands.Cog, name="general"):
         """
         [No arguments] Check if the bot is alive.
         """
-        embed = discord.Embed(
+        embed = nextcord.Embed(
             color=config["success"]
         )
         embed.add_field(
@@ -158,7 +158,7 @@ class general(commands.Cog, name="general"):
         [(Required) Question] Create a poll where members can vote on a question.
         """
         poll_title = " ".join(args)
-        embed = discord.Embed(
+        embed = nextcord.Embed(
             title="A new poll has been created!",
             description=f"{poll_title}",
             color=config["success"]

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -1,9 +1,9 @@
 import os
 import sys
 
-import discord
+import nextcord
 import yaml
-from discord.ext import commands
+from nextcord.ext import commands
 
 if "CompsciBot" not in str(os.getcwd()):
     os.chdir("./CompsciBot")
@@ -22,7 +22,7 @@ class Help(commands.Cog, name="help"):
         prefix = config["bot_prefix"]
         if not isinstance(prefix, str):
             prefix = prefix[0]
-        embed = discord.Embed(title="Help", description="List of available commands:", color=config["success"])
+        embed = nextcord.Embed(title="Help", description="List of available commands:", color=config["success"])
         for i in self.bot.cogs:
             cog = self.bot.get_cog(i.lower())
             if i not in ["owner", "template", "moderation"]:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1,9 +1,9 @@
 import os
 import sys
 import random
-import discord
+import nextcord
 import yaml
-from discord.ext import commands
+from nextcord.ext import commands
 
 if "CompsciBot" not in str(os.getcwd()):
     os.chdir("./CompsciBot")
@@ -16,12 +16,12 @@ class moderation(commands.Cog, name="moderation"):
 
     @commands.command(name='kick', pass_context=True)
     @commands.has_permissions(kick_members=True)
-    async def kick(self, context, member: discord.Member, *args):
+    async def kick(self, context, member: nextcord.Member, *args):
         """
         Kick a user out of the server.
         """
         if member.guild_permissions.administrator:
-            embed = discord.Embed(
+            embed = nextcord.Embed(
                 title="Error!",
                 description="User has Admin permissions.",
                 color=config["error"]
@@ -31,7 +31,7 @@ class moderation(commands.Cog, name="moderation"):
             try:
                 reason = " ".join(args)
                 await member.kick(reason=reason)
-                embed = discord.Embed(
+                embed = nextcord.Embed(
                     title="User Kicked!",
                     description=f"**{member}** was kicked by **{context.message.author}**!",
                     color=config["success"]
@@ -48,7 +48,7 @@ class moderation(commands.Cog, name="moderation"):
                 except:
                     pass
             except:
-                embed = discord.Embed(
+                embed = nextcord.Embed(
                     title="Error!",
                     description="An error occurred while trying to kick the user.",
                     color=config["success"]
@@ -57,7 +57,7 @@ class moderation(commands.Cog, name="moderation"):
 
     @commands.command(name="nick")
     @commands.has_permissions(manage_nicknames=True)
-    async def nick(self, context, member: discord.Member, *, name: str):
+    async def nick(self, context, member: nextcord.Member, *, name: str):
         """
         Change the nickname of a user on a server.
         """
@@ -65,7 +65,7 @@ class moderation(commands.Cog, name="moderation"):
             if name.lower() == "!reset":
                 name = None
             await member.edit(nick=name)
-            embed = discord.Embed(
+            embed = nextcord.Embed(
                 title="Changed Nickname!",
                 description=f"**{member}'s** new nickname is **{name}**!",
                 color=config["success"]
@@ -73,7 +73,7 @@ class moderation(commands.Cog, name="moderation"):
             await context.send(embed=embed)
         except Exception as e:
             print(e)
-            embed = discord.Embed(
+            embed = nextcord.Embed(
                 title="Error!",
                 description="An error occurred while trying to change the nickname of the user.",
                 color=config["success"]
@@ -82,13 +82,13 @@ class moderation(commands.Cog, name="moderation"):
 
     @commands.command(name="ban")
     @commands.has_permissions(ban_members=True)
-    async def ban(self, context, member: discord.Member, *args):
+    async def ban(self, context, member: nextcord.Member, *args):
         """
         Bans a user from the server.
         """
         try:
             if member.guild_permissions.administrator:
-                embed = discord.Embed(
+                embed = nextcord.Embed(
                     title="Error!",
                     description="User has Admin permissions.",
                     color=config["success"]
@@ -97,7 +97,7 @@ class moderation(commands.Cog, name="moderation"):
             else:
                 reason = " ".join(args)
                 await member.ban(reason=reason)
-                embed = discord.Embed(
+                embed = nextcord.Embed(
                     title="User Banned!",
                     description=f"**{member}** was banned by **{context.message.author}**!",
                     color=config["success"]
@@ -109,7 +109,7 @@ class moderation(commands.Cog, name="moderation"):
                 await context.send(embed=embed)
                 await member.send(f"You were banned by **{context.message.author}**!\nReason: {reason}")
         except:
-            embed = discord.Embed(
+            embed = nextcord.Embed(
                 title="Error!",
                 description="An error occurred while trying to ban the user.",
                 color=config["success"]
@@ -118,12 +118,12 @@ class moderation(commands.Cog, name="moderation"):
 
     @commands.command(name="warn")
     @commands.has_permissions(manage_messages=True)
-    async def warn(self, context, member: discord.Member, *args):
+    async def warn(self, context, member: nextcord.Member, *args):
         """
         Warns a user in their private messages.
         """
         reason = " ".join(args)
-        embed = discord.Embed(
+        embed = nextcord.Embed(
             title="User Warned!",
             description=f"**{member}** was warned by **{context.message.author}**!",
             color=config["success"]

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -1,9 +1,9 @@
 import os
 import sys
 
-import discord
+import nextcord
 import yaml
-from discord.ext import commands
+from nextcord.ext import commands
 
 if "CompsciBot" not in str(os.getcwd()):
     os.chdir("./CompsciBot")
@@ -20,7 +20,7 @@ class owner(commands.Cog, name="owner"):
         [No arguments] Make the bot shutdown
         """
         if context.message.author.id in config["owners"]:
-            embed = discord.Embed(
+            embed = nextcord.Embed(
                 description="Shutting down. Bye! :wave:",
                 color=config["success"]
             )
@@ -28,7 +28,7 @@ class owner(commands.Cog, name="owner"):
             await self.bot.logout()
             await self.bot.close()
         else:
-            embed = discord.Embed(
+            embed = nextcord.Embed(
                 title="Error!",
                 description="You don't have the permission to use this command.",
                 color=config["error"]
@@ -45,7 +45,7 @@ class owner(commands.Cog, name="owner"):
             await context.send(args)
             
         else:
-            embed = discord.Embed(
+            embed = nextcord.Embed(
                 title="Error!",
                 description="You don't have the permission to use this command.",
                 color=config["error"]
@@ -58,13 +58,13 @@ class owner(commands.Cog, name="owner"):
          [(Required) Words] The bot will say anything you want, but within embeds.
         """
         if context.message.author.id in config["owners"]:
-            embed = discord.Embed(
+            embed = nextcord.Embed(
                 description=args,
                 color=config["success"]
             )
             await context.send(embed=embed)
         else:
-            embed = discord.Embed(
+            embed = nextcord.Embed(
                 title="Error!",
                 description="You don't have the permission to use this command.",
                 color=config["error"]
@@ -77,7 +77,7 @@ class owner(commands.Cog, name="owner"):
         [(Required) User] Lets you add or remove a user from not being able to use the bot.
         """
         if context.invoked_subcommand is None:
-            embed = discord.Embed(
+            embed = nextcord.Embed(
                 title=f"There are currently {len(config['blacklist'])} blacklisted IDs",
                 description=f"{config['blacklist']}",
                 color=0x0000FF
@@ -85,7 +85,7 @@ class owner(commands.Cog, name="owner"):
             await context.send(embed=embed)
 
     @blacklist.command(name="add")
-    async def blacklist_add(self, context, member: discord.Member):
+    async def blacklist_add(self, context, member: nextcord.Member):
         """
         [(Required) User] Lets you add a user from not being able to use the bot.
         """
@@ -93,7 +93,7 @@ class owner(commands.Cog, name="owner"):
             userID = member.id
             try:
                 config["blacklist"].append(userID)
-                embed = discord.Embed(
+                embed = nextcord.Embed(
                     title="User Blacklisted",
                     description=f"**{member.name}** has been successfully added to the blacklist",
                     color=config["success"]
@@ -103,14 +103,14 @@ class owner(commands.Cog, name="owner"):
                 )
                 await context.send(embed=embed)
             except:
-                embed = discord.Embed(
+                embed = nextcord.Embed(
                     title="Error!",
                     description=f"An unknown error occurred when trying to add **{member.name}** to the blacklist.",
                     color=config["error"]
                 )
                 await context.send(embed=embed)
         else:
-            embed = discord.Embed(
+            embed = nextcord.Embed(
                 title="Error!",
                 description="You don't have the permission to use this command.",
                 color=config["error"]
@@ -118,7 +118,7 @@ class owner(commands.Cog, name="owner"):
             await context.send(embed=embed)
 
     @blacklist.command(name="remove")
-    async def blacklist_remove(self, context, member: discord.Member):
+    async def blacklist_remove(self, context, member: nextcord.Member):
         """
         [(Required) User] Lets you remove a user from not being able to use the bot.
         """
@@ -126,7 +126,7 @@ class owner(commands.Cog, name="owner"):
             userID = member.id
             try:
                 config["blacklist"].remove(userID)
-                embed = discord.Embed(
+                embed = nextcord.Embed(
                     title="User Unblacklisted",
                     description=f"**{member.name}** has been successfully removed from the blacklist",
                     color=config["success"]
@@ -136,14 +136,14 @@ class owner(commands.Cog, name="owner"):
                 )
                 await context.send(embed=embed)
             except:
-                embed = discord.Embed(
+                embed = nextcord.Embed(
                     title="Error!",
                     description=f"An unknown error occurred when trying to remove **{member.name}** from the blacklist.",
                     color=config["error"]
                 )
                 await context.send(embed=embed)
         else:
-            embed = discord.Embed(
+            embed = nextcord.Embed(
                 title="Error!",
                 description="You don't have the permission to use this command.",
                 color=config["error"]

--- a/cogs/ratemyprofessor.py
+++ b/cogs/ratemyprofessor.py
@@ -1,8 +1,8 @@
 import os
 import sys
-import discord
+import nextcord
 import yaml
-from discord.ext import commands
+from nextcord.ext import commands
 import ratemyprofessor
 
 if "CompsciBot" not in str(os.getcwd()):
@@ -26,23 +26,26 @@ class RateMyProfessor(commands.Cog, name="rate my professor"):
         """
         [(Required) Professor name] Check out what RateMyProfessor has to say about a professor!
         """
-        professorSearchTerm = " ".join(professorArgs)
-        EMU = ratemyprofessor.get_school_by_name("Eastern Michigan University")
-        prof = ratemyprofessor.get_professor_by_school_and_name(EMU, professorSearchTerm)
+        try:
+            professorSearchTerm = " ".join(professorArgs)
+            EMU = ratemyprofessor.get_school_by_name("Eastern Michigan University")
+            prof = ratemyprofessor.get_professor_by_school_and_name(EMU, professorSearchTerm)
 
-        ratingsBest = sorted([rating for rating in prof.get_ratings() if rating.comment], key=lambda rating: (rating.rating, rating.date))
-        bestRating = ratingsBest[-1]
+            ratingsBest = sorted([rating for rating in prof.get_ratings() if rating.comment], key=lambda rating: (rating.rating, rating.date))
+            bestRating = ratingsBest[-1]
 
-        ratingsWorst = sorted([rating for rating in prof.get_ratings() if rating.comment], key=lambda rating: (-rating.rating, rating.date))
-        worstRating = ratingsWorst[-1]
+            ratingsWorst = sorted([rating for rating in prof.get_ratings() if rating.comment], key=lambda rating: (-rating.rating, rating.date))
+            worstRating = ratingsWorst[-1]
 
-        profEmbed = self.buildProfEmbed(prof)
-        bestembed = self.buildRatingEmbed(discord.Embed(title=f"Best Rating for {prof.name}", color=config["success"]), bestRating)
-        worstembed = self.buildRatingEmbed(discord.Embed(title=f"Worst Rating for {prof.name}",color=config["success"]), worstRating)
-        
-        await context.send(embed=profEmbed)
-        await context.send(embed=bestembed)
-        await context.send(embed=worstembed)
+            profEmbed = self.buildProfEmbed(prof)
+            bestembed = self.buildRatingEmbed(nextcord.Embed(title=f"Best Rating for {prof.name}", color=config["success"]), bestRating)
+            worstembed = self.buildRatingEmbed(nextcord.Embed(title=f"Worst Rating for {prof.name}",color=config["success"]), worstRating)
+            
+            await context.send(embed=profEmbed)
+            await context.send(embed=bestembed)
+            await context.send(embed=worstembed)
+        except:
+            await context.send(f"Could not find professor '{professorSearchTerm}'. Try only using a last name or check your spelling!")
 
     def buildRatingEmbed(self, embed, rating):
         if rating.rating:
@@ -90,7 +93,7 @@ class RateMyProfessor(commands.Cog, name="rate my professor"):
         return embed
     
     def buildProfEmbed(self, prof):
-        embed = discord.Embed(
+        embed = nextcord.Embed(
             title=prof,
             color=config["success"]
         )

--- a/cogs/template.py
+++ b/cogs/template.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import yaml
-from discord.ext import commands
+from nextcord.ext import commands
 
 if "CompsciBot" not in str(os.getcwd()):
     os.chdir("./CompsciBot")

--- a/noncommands/summarizer.py
+++ b/noncommands/summarizer.py
@@ -7,7 +7,7 @@ from nltk.corpus import stopwords
 from nltk.tokenize import word_tokenize
 from trafilatura import bare_extraction
 import trafilatura
-import discord
+import nextcord
 
 
 nltk.download('punkt')
@@ -80,7 +80,7 @@ def getSummary(config, url):
     numSent = 5
     downloaded = trafilatura.fetch_url(url)
     article = bare_extraction(downloaded)
-    embed = discord.Embed(
+    embed = nextcord.Embed(
         color=config["success"]
     )
     embed.add_field(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 aiohttp
 apscheduler
 asyncio
-discord
-discord.py[voice]
+nextcord
 pyyaml
 aiofiles
 schedule


### PR DESCRIPTION
This PR switches from discord.py to [nextcord](https://docs.nextcord.dev/en/stable/). It is a maintained fork of discord.py and supports all the modern features.

This PR also removes accidental references to dad bot that I did not notice when porting over commands, as well as fixing an issue with rate my professor that caused there to be no response if a person misspelled a teacher's name