### PR TITLE
fix deploy script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+    branches:
+      - main
 name: 🚀 Deploy bot on push
 jobs:
   web-deploy:


### PR DESCRIPTION
Currently the deploy script deploys we've any commit is committed to any branch.

This PR makes it so that the deploy script only runs with something is pushed to the `main` branch.