### PR TITLE
feat: ✨ add /classrolesreactions command

### DIFF
--- a/cogs/channel.py
+++ b/cogs/channel.py
@@ -85,7 +85,7 @@ def read_class_json(file_name: str) -> SectionJson:
         return data
 
 
-course_name_regex = re.compile('(COSC|MATH|STAT)[- ]([0-9]{3})')
+course_name_regex = re.compile('(COSC|MATH|STAT)[- ]([0-9]{3})', re.I)
 term_name_regex = re.compile('([A-Z][a-z]+)[- ](20[0-9]{2})')
 
 

--- a/cogs/channel.py
+++ b/cogs/channel.py
@@ -84,6 +84,9 @@ def read_class_json(file_name: str) -> SectionJson:
         return data
 
 
+course_name_regex = re.compile('(COSC|MATH|STAT)[- ]([0-9]{3})')
+
+
 async def create_category(category_name, interaction: Interaction):
     """
     creates a category and returns category object
@@ -238,12 +241,12 @@ class ChannelManager(Cog, name="channelmanager"):
         coroutines = []
 
         for channel in interaction.guild.channels:
-            if re.search('(COSC|MATH|STAT)-[0-9]{3}', channel.name, flags=re.I):
+            if course_name_regex.search(channel.name):
                 coroutines.append(channel.delete())
                 channels_count += 1
 
         for role in interaction.guild.roles:
-            if re.search('(COSC|MATH|STAT) [0-9]{3}', role.name, flags=re.I):
+            if course_name_regex.search(role.name):
                 coroutines.append(role.delete())
                 roles_count += 1
 


### PR DESCRIPTION
Adds a command `/classrolesreactions` which will generate the commands to add reaction roles with carl bot

it does this by looking at the roles currently in existence

it assumes the roles are of the form `AAAA ### Aaaa...a 20##`
it assumes that all roles belong to the same term (semester)

roles are separated into 2 groups based on weather they start with a 1, 2, or 3 or start with a 4, 5, or 6

this is because discord only allows 20 reactions on a single message