### PR TITLE
feat: ✨ allow mentioning any role within a class channel rather than allowing a class to be mentioned anywhere

### DIFF
--- a/cogs/channel.py
+++ b/cogs/channel.py
@@ -121,14 +121,15 @@ async def create_role(interaction: Interaction, role_name: str, permissions: Per
 
 async def create_role_for_category(interaction: Interaction, category: nextcord.CategoryChannel, term: str):
     role_name = f"{category.name.replace('-', ' ')} {term}"
-    role = await create_role(interaction, role_name, color=nextcord.Colour.blue(), mentionable=True)
+    role = await create_role(interaction, role_name, color=nextcord.Colour.blue())
     # gives basic permissions to a role for its assigned channel
     await category.set_permissions(
         role,
         read_messages=True,
         send_messages=True,
         add_reactions=True,
-        read_message_history=True
+        read_message_history=True,
+        mention_everyone=True
     )
     return role
 


### PR DESCRIPTION
Before this PR:
- Anyone can mention any class in any channel

After this PR:
- Anyone can mention any role in a class channel

Things no longer possible after this PR:
- someone doing `@COSC 381 Winter 2023` in `#genral`

Things that are still possible after this PR:
- someone doing `@COSC 381 Winter 2023` in `#cosc-381-jiang`

Things that are now possible after this PR:
- someone doing `@everyone` in `#cosc-381-jiang`
- someone doing `@here` in `#cosc-381-jiang`
- someone doing `@admin` in `#cosc-381-jiang`

Note: you will not receive notifications for `@everyone` if you are not in a channel or if you have muted the channel.